### PR TITLE
remove unnecessary mutex

### DIFF
--- a/imageNotifier/imageNotifier.go
+++ b/imageNotifier/imageNotifier.go
@@ -103,21 +103,19 @@ func (r *ImageNotifier) checkAllImageNotifyList() {
 
 	// dump all checkList
 	checkList := func() []checkImage {
-		checkList := make([]checkImage, 0)
+		list := make([]checkImage, 0)
 		r.mutex.RLock()
-		defer r.mutex.RUnlock()
 		for _, imageUpdateNotify := range r.list {
 			if imageUpdateNotify != nil {
-				imageUpdateNotify.mutex.Lock()
-				checkList = append(checkList, checkImage{
+				list = append(list, checkImage{
 					controller: imageUpdateNotify.controller,
 					url:        imageUpdateNotify.url,
 					tag:        imageUpdateNotify.tag,
 				})
-				imageUpdateNotify.mutex.Unlock()
 			}
 		}
-		return checkList
+		r.mutex.RUnlock()
+		return list
 	}()
 
 	for _, check := range checkList {


### PR DESCRIPTION
다음 사항을 수정했습니다.

- `ImageUpdateNotify`의 `mutex` 제거
- `ImageUpdateNotify`의 `referenceCount`를 atomic으로 증감하도록 수정
- `checkList` 함수의 `checkList` 변수명 변경

`mutex`가 없어도 되는 이유는 다음과 같습니다.
- `ImageUpdateNotify`의 state 는 `referenceCount`를 제외하고 변하지 않음
- `ImageNotifier`가 `list`에 접근 시 별도로 lock을 잡기 때문에 문제가 없음