### PR TITLE
remove potential data race

### DIFF
--- a/controller/sync.go
+++ b/controller/sync.go
@@ -129,13 +129,15 @@ func (c *Controller) registImage(image Image) {
 
 func (c *Controller) unregistImage(image Image) {
 
+	c.syncedImagesMutex.Lock()
+
 	if !c.syncedImages[image] { // 이미 제거된 이미지
+		c.syncedImagesMutex.Unlock()
 		return
 	}
 
 	c.logger.Infof("[%s] unregistImage image=%+v\n", c.resource, image)
 
-	c.syncedImagesMutex.Lock()
 	delete(c.syncedImages, image)
 	c.syncedImagesMutex.Unlock()
 


### PR DESCRIPTION
`c.syncedImages`에 접근하는 모든 상황에서 락을 잡도록 수정했습니다.